### PR TITLE
add --disable-arp option

### DIFF
--- a/lurker.go
+++ b/lurker.go
@@ -17,6 +17,7 @@ type lurker struct {
 	pcapHandle  *pcap.Handle
 	isOnTheFly  bool
 	dryRun      bool
+	disableArp  bool
 	targetAddrs []string
 
 	awsRegion   string
@@ -154,7 +155,9 @@ func (x *lurker) loop() error {
 	pktHandlers := packetHandlers{dh}
 
 	if !x.dryRun && x.isOnTheFly {
-		pktHandlers = append(pktHandlers, newArpHandler(x.pcapHandle, x.sourceName, x.targetAddrs))
+		if !x.disableArp {
+			pktHandlers = append(pktHandlers, newArpHandler(x.pcapHandle, x.sourceName, x.targetAddrs))
+		}
 		pktHandlers = append(pktHandlers, newTcpHandler(x.pcapHandle, x.targetAddrs))
 	}
 

--- a/main.go
+++ b/main.go
@@ -16,6 +16,7 @@ type options struct {
 	Target      string `short:"t" description:"Target Address" value-name:"IPADDR"`
 	AwsRegion   string `long:"aws-region"`
 	AwsS3Bucket string `long:"aws-s3-bucket"`
+	DisableArp  bool   `long:"disable-arp" description:"Disable ARP responder"`
 	Verbose     bool   `short:"v" long:"verbose" description:"Verbose output"`
 }
 
@@ -59,6 +60,8 @@ func main() {
 	if opts.AwsRegion != "" && opts.AwsS3Bucket != "" {
 		lkr.setS3Bucket(opts.AwsRegion, opts.AwsS3Bucket)
 	}
+
+	lkr.disableArp = opts.DisableArp
 
 	if err := lkr.loop(); err != nil {
 		logger.Fatal(err)


### PR DESCRIPTION
This commit introduces --disable-arp option that disable arpHandler. Disabling ARP proxy enables lurker to run on an interface that actually has IP address(es).

Practically, a network stack sends TCP RST even when lurker sends TCP SYN,ACK. Thus, it needs to discard TCP RST from the host. For example, sudo iptables -A OUTPUT -p tcp --tcp-flags RST RST -o ens160 -j DROP.