### PR TITLE
add make install and install-systemd

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,2 @@
-lurker
+/lurker
 vendor

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,16 @@
 all: lurker
 
-lurker: *.go lib/*.go
+lurker: *.go
+	go mod download
 	go build -o lurker
 
-test: *.go lib/*.go
-	go test . ./lib
+test: *.go
+	go test .
+
+
+install: lurker
+	/usr/bin/install -m 755 -D lurker /usr/local/bin/
+
+install-systemd: install
+	/usr/bin/install -m 644 -D systemd/lurker /etc/default/
+	/usr/bin/install -m 644 -D systemd/lurker.service /lib/systemd/system/

--- a/systemd/lurker
+++ b/systemd/lurker
@@ -1,0 +1,5 @@
+#
+# Lurker options
+#
+# To run Lurker, specify "-i DEV" to LURKER_OPTS at least
+LURKER_OPTS=""

--- a/systemd/lurker.service
+++ b/systemd/lurker.service
@@ -1,0 +1,14 @@
+[Unit]
+Description=lurker: Low interaction honeypot in GO
+After=network.target
+
+[Service]
+EnvironmentFile=-/etc/default/lurker
+ExecStart=/usr/local/bin/lurker $LURKER_OPTS
+KillMode=process
+Type=simple
+
+[Install]
+WantedBy=multi-user.target
+Alias=lurker.service
+


### PR DESCRIPTION
This commit fixes Makefile, and add make install and install-systemd.
make install-systemd adds /etc/default/lurker for specifying lurker
options, and /lib/systemd/system/lurker.

To run lurker through systemd,
```
systemctl enable lurker
systemctl start lurker
```